### PR TITLE
Remove retries from tests

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,7 @@ test_selenium () {
 
     # run tests for each browser
     echo "Running tests for Chrome"
-    JEST_JUNIT_OUTPUT_DIR=$GITHUB_WORKSPACE/reports JEST_JUNIT_OUTPUT_NAME=selenium-chrome-tests-report-$FILE_NAME.xml selenium-side-runner -c "browserName=chrome goog:chromeOptions.args=[headless, no-sandbox, remote-debugging-port=9222, disable-web-security, disable-features=IsolateOrigins,site-per-process]" -z $GITHUB_WORKSPACE/screenshots --retries 1 --output-directory $GITHUB_WORKSPACE/reports -j " --reporters=jest-junit  --reporters=default " --timeout 5000 --base-url $2 $1
+    JEST_JUNIT_OUTPUT_DIR=$GITHUB_WORKSPACE/reports JEST_JUNIT_OUTPUT_NAME=selenium-chrome-tests-report-$FILE_NAME.xml selenium-side-runner -c "browserName=chrome goog:chromeOptions.args=[headless, no-sandbox, remote-debugging-port=9222, disable-web-security, disable-features=IsolateOrigins,site-per-process]" -z $GITHUB_WORKSPACE/screenshots --output-directory $GITHUB_WORKSPACE/reports -j " --reporters=jest-junit  --reporters=default " --timeout 5000 --base-url $2 $1
 
     echo "######## Tests complete for '$1' ########\n"
 }


### PR DESCRIPTION
Removing the `--retries` flag from tests for now since it seems to just repeat the test instead of actually retrying when it fails. In the future, an option to specify retries should be added to the action.